### PR TITLE
feat(MCP): Make Wiki-RAG to behave as a MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To get started with Wiki-RAG, ensure you have the following:
    - `wr-index`: In charge of creating the collection in the vector index (Milvus) with all the information extracted in the previous step.
    - `wr-search`: A tiny CLI utility to perform searches against the RAG system from the command line.
    - `wr-server`: A comprehensive and secure web service (documented with OpenAPI) that allows users to interact with the RAG system using the OpenAI API (`v1/models` and `v1/chat/completions` endpoints) as if it were a large language model (LLM).
+   - `wr-mcp`: A complete and **UNPROTECTED** built-in MCP server that allows you to access to various parts of Wiki-RAG like prompts (system and use prompt with placeholders), resources (access to the source parsed documents) and tools (retrieve, optimise and generate) using the [MCP Protocol](https://modelcontextprotocol.io/).
 
 ### Running with Docker (Milvus elsewhere)
 

--- a/env_template
+++ b/env_template
@@ -32,6 +32,9 @@ WRAPPER_CHAT_MAX_TOKENS=1536
 # Public name that the wrapper will use to identify itself as a model. Will default to COLLECTION_NAME is not set.
 WRAPPER_MODEL_NAME="Your Model Name"
 
+# Model Context Protocol (MCP) base URL.
+MCP_API_BASE="0.0.0.0:8081"
+
 # Validate requests auth against these bearer tokens.
 AUTH_TOKENS="11111111,22222222,33333333"
 # Delegate bearer token auth to this URL.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "langchain-openai == 0.3.7",
     "langgraph == 0.3.5",
     "langsmith == 0.3.11",
+    "mcp[cli] == 1.5.0",
     "pymilvus == 2.5.4",
     "python-dotenv == 1.0.1",
     "tiktoken == 0.9.0",
@@ -60,6 +61,7 @@ wr-load = "wiki_rag.load.main:main"
 wr-index = "wiki_rag.index.main:main"
 wr-search = "wiki_rag.search.main:main"
 wr-server = "wiki_rag.server.main:main"
+wr-mcp = "wiki_rag.mcp_server.main:main"
 
 [project.urls]
 Homepage = "https://github.com/moodlehq/wiki-rag"

--- a/wiki_rag/mcp_server/__init__.py
+++ b/wiki_rag/mcp_server/__init__.py
@@ -1,0 +1,9 @@
+#  Copyright (c) 2025, Moodle HQ - Research
+#  SPDX-License-Identifier: BSD-3-Clause
+
+"""wiki_rag.mcp_server package."""
+
+from pathlib import Path
+
+# The file that will be used to provide resources.
+res_file: Path | None = None

--- a/wiki_rag/mcp_server/main.py
+++ b/wiki_rag/mcp_server/main.py
@@ -1,0 +1,170 @@
+#  Copyright (c) 2025, Moodle HQ - Research
+#  SPDX-License-Identifier: BSD-3-Clause
+
+"""Main entry point for the knowledge base MCP compatible server."""
+
+import logging
+import os
+import sys
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+from langchain_core.runnables import RunnableConfig
+
+import wiki_rag.index as index
+import wiki_rag.mcp_server as mcp_global
+
+from wiki_rag import LOG_LEVEL, ROOT_DIR, __version__, server
+from wiki_rag.search.util import ConfigSchema
+from wiki_rag.util import setup_logging
+
+
+def main():
+    """Run the MCP server with all the configuration in place."""
+    setup_logging(level=LOG_LEVEL)
+    logger = logging.getLogger(__name__)
+    logger.info("wiki_rag-server-mcp_server starting up...")
+
+    # Print the version of the bot.
+    logger.warning(f"Version: {__version__}")
+
+    dotenv_file = ROOT_DIR / ".env"
+    if dotenv_file.exists():
+        logger.warning("Loading environment variables from %s", dotenv_file)
+        logger.warning("Note: .env files are not supposed to be used in production. Use env secrets instead.")
+        load_dotenv(dotenv_file)
+
+    mediawiki_url = os.getenv("MEDIAWIKI_URL")
+    if not mediawiki_url:
+        logger.error("Mediawiki URL not found in environment. Exiting.")
+        sys.exit(1)
+
+    mediawiki_namespaces = os.getenv("MEDIAWIKI_NAMESPACES")
+    if not mediawiki_namespaces:
+        logger.error("Mediawiki namespaces not found in environment. Exiting.")
+        sys.exit(1)
+    mediawiki_namespaces = mediawiki_namespaces.split(",")
+    mediawiki_namespaces = [int(ns.strip()) for ns in mediawiki_namespaces]  # no whitespace and int.
+    mediawiki_namespaces = list(set(mediawiki_namespaces))  # unique
+
+    loader_dump_path = os.getenv("LOADER_DUMP_PATH")
+    if loader_dump_path:
+        loader_dump_path = Path(loader_dump_path)
+    else:
+        loader_dump_path = ROOT_DIR / "data"
+    # If the directory does not exist, create it.
+    if not loader_dump_path.exists():
+        logger.warning(f"Data directory {loader_dump_path} not found. Creating it.")
+        try:
+            loader_dump_path.mkdir()
+        except Exception:
+            logger.error(f"Could not create data directory {loader_dump_path}. Exiting.")
+            sys.exit(1)
+
+    collection_name = os.getenv("COLLECTION_NAME")
+    if not collection_name:
+        logger.error("Collection name not found in environment. Exiting.")
+        sys.exit(1)
+        # TODO: Validate that only numbers, letters and underscores are used.
+
+    index.milvus_url = os.getenv("MILVUS_URL")
+    if not index.milvus_url:
+        logger.error("Milvus URL not found in environment. Exiting.")
+        sys.exit(1)
+
+    # If tracing is enabled, put a name for the project.
+    if os.getenv("LANGSMITH_TRACING", "false") == "true":
+        os.environ["LANGSMITH_PROJECT"] = f"{collection_name}"
+
+    user_agent = os.getenv("USER_AGENT")
+    if not user_agent:
+        logger.info("User agent not found in environment. Using default.")
+        user_agent = "Moodle Research Crawler/{version} (https://git.in.moodle.com/research)"
+    user_agent = f"{user_agent.format(version=__version__)}"
+
+    embedding_model = os.getenv("EMBEDDING_MODEL")
+    if not embedding_model:
+        logger.error("Embedding model not found in environment. Exiting.")
+        sys.exit(1)
+
+    embedding_dimensions = os.getenv("EMBEDDING_DIMENSIONS")
+    if not embedding_dimensions:
+        logger.error("Embedding dimensions not found in environment. Exiting.")
+        sys.exit(1)
+    embedding_dimensions = int(embedding_dimensions)
+
+    llm_model = os.getenv("LLM_MODEL")
+    if not llm_model:
+        logger.error("LLM model not found in environment. Exiting.")
+        sys.exit(1)
+
+    mcp_api_base = os.getenv("MCP_API_BASE")
+    if not mcp_api_base:
+        logger.error("MCP API base not found in environment. Exiting.")
+        sys.exit(1)
+    parts = mcp_api_base.split(":")
+    mcp_server = parts[0]
+    if len(parts) > 1:
+        mcp_port = int(parts[1])
+    else:
+        mcp_port = 8081
+
+    # Calculate the file that we are going to use as source for the resources.
+    input_candidate = ""
+    for file in sorted(loader_dump_path.iterdir()):
+        if file.is_file() and file.name.startswith(collection_name) and file.name.endswith(".json"):
+            input_candidate = file
+    if input_candidate:
+        mcp_global.res_file = loader_dump_path / input_candidate
+
+    if not mcp_global.res_file:
+        logger.warning(f"No input file found in {loader_dump_path} with collection name {collection_name}.")
+
+    # These are optional, default to 0 (unlimited).
+    wrapper_chat_max_turns = int(os.getenv("WRAPPER_CHAT_MAX_TURNS", 0))
+    wrapper_chat_max_tokens = int(os.getenv("WRAPPER_CHAT_MAX_TOKENS", 0))
+    wrapper_model_name = os.getenv("WRAPPER_MODEL_NAME") or os.getenv("COLLECTION_NAME")
+    if not wrapper_model_name:
+        logger.error("Public wrapper name not found in environment. Exiting.")  # This is unreachable.
+        sys.exit(1)
+
+    # Prepare the configuration schema.
+    # TODO, make prompt name, task_def, kb_*, cutoff, max tokens, temperature, top_p
+    #  configurable. With defaults applied if not configured.
+    config_schema = ConfigSchema(
+        prompt_name="moodlehq/wiki-rag",
+        task_def="Moodle user documentation",
+        kb_name="Moodle Docs",
+        kb_url=mediawiki_url,
+        collection_name=collection_name,
+        embedding_model=embedding_model,
+        embedding_dimension=embedding_dimensions,
+        llm_model=llm_model,
+        search_distance_cutoff=0.6,
+        max_completion_tokens=768,
+        temperature=0.05,
+        top_p=0.85,
+        stream=False,
+        wrapper_chat_max_turns=wrapper_chat_max_turns,
+        wrapper_chat_max_tokens=wrapper_chat_max_tokens,
+        wrapper_model_name=wrapper_model_name,
+    ).items()
+
+    # Prepare the configuration.
+    server.config = RunnableConfig(configurable=dict(config_schema))
+
+    # Start the mcp_server server
+    from wiki_rag.mcp_server.server import mcp
+
+    mcp.settings.host = mcp_server
+    mcp.settings.port = mcp_port
+    mcp.run("sse")
+    # import asyncio
+    # asyncio.run(mcp_server.run_sse_async())
+
+    logger.info("wiki_rag-server-mcp_server finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/wiki_rag/mcp_server/server.py
+++ b/wiki_rag/mcp_server/server.py
@@ -1,0 +1,207 @@
+#  Copyright (c) 2025, Moodle HQ - Research
+#  SPDX-License-Identifier: BSD-3-Clause
+
+"""Simple MCP server example providing a few tools, resources and prompts."""
+
+import logging
+
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    PromptTemplate,
+    SystemMessagePromptTemplate,
+)
+from mcp.server.fastmcp import FastMCP
+
+import wiki_rag.mcp_server as mcp_global
+
+from wiki_rag import server
+from wiki_rag.index.util import load_parsed_information
+from wiki_rag.mcp_server.util import build_optimise_graph, build_retrieve_graph
+from wiki_rag.search.util import build_graph, load_prompts_for_rag
+from wiki_rag.server.server import invoke_graph
+from wiki_rag.server.util import (
+    Message,
+    convert_from_openai_to_langchain,
+)
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("Wiki-RAG MCP Server")
+
+
+@mcp.tool()
+async def retrieve(messages: list[Message]) -> dict[str, list[str]]:
+    """Get the raw results from the database."""
+    assert server.config is not None and "configurable" in server.config
+
+    # Extract the last message, our new question, out from history.
+    question = messages.pop()["content"]
+
+    # Convert the messages to the format expected by langgraph.
+    history = convert_from_openai_to_langchain(messages)
+
+    logger.info("Building the retrieve graph")
+    server.graph = build_retrieve_graph()
+
+    logger.info("Running retrieve (non-streaming)")
+    response = await invoke_graph(
+        question=question,
+        history=history,
+        config=server.config
+    )
+    logger.debug(f"Response: {response}")
+    return {
+        "vector_search": response["vector_search"]
+    }
+
+
+@mcp.tool()
+async def optimise(messages: list[Message]) -> dict[str, list[str]]:
+    """Get the optimised results from the retrieved ones."""
+    assert server.config is not None and "configurable" in server.config
+
+    # Extract the last message, our new question, out from history.
+    question = messages.pop()["content"]
+
+    # Convert the messages to the format expected by langgraph.
+    history = convert_from_openai_to_langchain(messages)
+
+    logger.info("Building the optimise graph")
+    server.graph = build_optimise_graph()
+
+    logger.info("Running optimise (non-streaming)")
+    response = await invoke_graph(
+        question=question, history=history, config=server.config
+    )
+    logger.debug(f"Response: {response}")
+    return {
+        "context": response["context"],
+        "sources": response["sources"],
+    }
+
+
+@mcp.tool()
+async def generate(messages: list[Message]) -> str:
+    """Get the LLM generated answer after retrieving and optimising."""
+    assert server.config is not None and "configurable" in server.config
+
+    # Extract the last message, our new question, out from history.
+    question = messages.pop()["content"]
+
+    # Convert the messages to the format expected by langgraph.
+    history = convert_from_openai_to_langchain(messages)
+
+    logger.info("Building the generate complete graph")
+    server.graph = build_graph()
+
+    logger.info("Running generate (non-streaming)")
+    response = await invoke_graph(
+        question=question, history=history, config=server.config
+    )
+    logger.debug(f"Response: {response}")
+    return response["answer"]
+
+
+# Add a resource that returns the first 10 parsed pages.
+@mcp.resource("resource://get_10_pages")
+def get_10_pages() -> list[dict]:
+    """Get the first 10 parsed pages."""
+    logger.info("Resource: Getting 10 pages")
+    # First of all, load the json from the resource file and verify that everything is ok.
+    if mcp_global.res_file is None:
+        error_msg = "Error: resource file not set."
+        raise RuntimeError(error_msg)
+    pages = load_parsed_information(mcp_global.res_file)
+    if not pages:
+        error_msg = f"Error: loading and parsing the resource file {mcp_global.res_file}."
+        raise RuntimeError(error_msg)
+
+    return pages[:10]
+
+
+# Add a resource that returns the first 100 parsed pages.
+@mcp.resource("resource://get_100_pages")
+def get_100_pages() -> list[dict]:
+    """Get the first 100 parsed pages."""
+    logger.info("Resource: Getting 100 pages")
+    # First of all, load the json from the resource file and verify that everything is ok.
+    if mcp_global.res_file is None:
+        error_msg = "Error: resource file not set."
+        raise RuntimeError(error_msg)
+    pages = load_parsed_information(mcp_global.res_file)
+    if not pages:
+        error_msg = f"Error: loading and parsing the resource file {mcp_global.res_file}."
+        raise RuntimeError(error_msg)
+
+    return pages[:100]
+
+
+# Add a resource template that accepts start and number of pages to return.
+@mcp.resource("resource://get_pages/{start}/{number}")
+def get_pages(start: int, number: int) -> list[dict]:
+    """Get "number" parsed pages, starting from "start"."""
+    logger.info(f"Resource: Getting {number} pages starting at {start}")
+    # First of all, load the json from the resource file and verify that everything is ok.
+    if mcp_global.res_file is None:
+        error_msg = "Error: resource file not set."
+        raise RuntimeError(error_msg)
+    pages = load_parsed_information(mcp_global.res_file)
+    if not pages:
+        error_msg = f"Error: loading and parsing the resource file {mcp_global.res_file}."
+        raise RuntimeError(error_msg)
+    # Check that the start and number are valid.
+    if (start - 1 + number) > len(pages):
+        error_msg = f"Error: start ({start}) and number ({number}) are out of range."
+        raise ValueError(error_msg)
+    if start < 1:
+        error_msg = f"Error: start ({start}) must be greater than 0."
+        raise ValueError(error_msg)
+
+    return pages[start - 1:start - 1 + number]
+
+
+@mcp.prompt()
+def get_system_prompt(
+        task_def: str = "{task_def}",
+        kb_name: str = "{kb_name}",
+        kb_url: str = "{kb_url}",
+) -> str:
+    """Get the system prompt used for LLM generation."""
+    prompt: ChatPromptTemplate = load_prompts_for_rag("moodlehq/wiki-rag")  # Get the prompt.
+    system_prompt = [
+        message.prompt
+        for message in prompt.messages
+            if isinstance(message, SystemMessagePromptTemplate)
+    ][0]
+    assert (isinstance(system_prompt, PromptTemplate)), "System prompt not found."
+    raw = system_prompt.template
+    logger.debug(f"Raw system prompt: {raw}")
+    return raw.format(
+        task_def=task_def,
+        kb_name=kb_name,
+        kb_url=kb_url,
+    )
+
+
+@mcp.prompt()
+def get_user_prompt(
+        question: str = "{question}",
+        context: str = "{context}",
+        sources: str = "{sources}",
+) -> str:
+    """Get the user prompt used for LLM generation."""
+    prompt: ChatPromptTemplate = load_prompts_for_rag(prompt_name="moodlehq/wiki-rag")  # Get the prompt.
+    user_prompt = [
+        message.prompt
+        for message in prompt.messages
+            if isinstance(message, HumanMessagePromptTemplate)
+    ][0]
+    assert (isinstance(user_prompt, PromptTemplate)), "User prompt not found."
+    raw = user_prompt.template
+    logger.debug(f"Raw user prompt: {raw}")
+    return raw.format(
+        question=question,
+        context=context,
+        sources=sources,
+    )

--- a/wiki_rag/mcp_server/util.py
+++ b/wiki_rag/mcp_server/util.py
@@ -1,0 +1,35 @@
+#  Copyright (c) 2025, Moodle HQ - Research
+#  SPDX-License-Identifier: BSD-3-Clause
+
+"""Util functions to generate the graphs used by the MCP server."""
+
+import logging
+
+from langgraph.constants import START
+from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from wiki_rag.search.util import ConfigSchema, RagState, optimise, retrieve
+
+logger = logging.getLogger(__name__)
+
+
+def build_retrieve_graph() -> CompiledStateGraph:
+    """Build the retrieve only graph for the retrieve MCP tool."""
+    graph_builder = StateGraph(RagState, ConfigSchema).add_sequence([
+        retrieve,
+    ])
+    graph_builder.add_edge(START, "retrieve")
+    graph = graph_builder.compile()
+    return graph
+
+
+def build_optimise_graph() -> CompiledStateGraph:
+    """Build the retrieve and optimise graph for the optimise MCP tool."""
+    graph_builder = StateGraph(RagState, ConfigSchema).add_sequence([
+        retrieve,
+        optimise,
+    ])
+    graph_builder.add_edge(START, "retrieve")
+    graph = graph_builder.compile()
+    return graph


### PR DESCRIPTION
This brings Model Context Protocol (MCP) server support to Wiki-RAG providing all the features already available in the OpenAI server and more:

- Prompts:
  - get_system_prompt: Get the system prompt, optionally parsing arguments.
  - get_user_prompt: Get the user prompt, optionally parsing arguments.
- Tools:
  - retrieve: Get the raw results from the (vector) database.
  - optimise: Post-process the results providing the optimised context and sources.
  - generate: Run the whole stack, returning the answer from the LLM.
- Resources:
  - get_10_pages: Return the first 10 parsed pages from the target wikis.
  - get_100_pages: Return the first 100 parsed pages from the target wikis.
  - get_pages/start/number: Return the specified number of pages from a given start.

Important: The whole MCP server is UNPROTECTED, so take it into
  account depending of the deployments planned.

This is only a demo implementation to play with MCP and see how easy is to transform any other existing API to be MCP-compatible.

Fixes #4