### PR TITLE
Add rate limit control

### DIFF
--- a/env_template
+++ b/env_template
@@ -6,7 +6,7 @@ OPENAI_API_BASE="https://openai.com/v1"
 # OPENAI_API_KEY="<<<YOUR_OPENAI_API_KEY>>>"
 
 # Mediawiki instance base URL.
-MEDIAWIKI_URL="https://your.mediaiki/base/url
+MEDIAWIKI_URL="https://your.mediawiki/base/url"
 # Comma separated list (general and others, see https://www.mediawiki.org/wiki/Manual:Namespace#Built-in_namespaces)
 MEDIAWIKI_NAMESPACES="0,4,12"
 MEDIAWIKI_EXCLUDED="categories:Category A, Category B;wikitext:Some regex to exclude"

--- a/env_template
+++ b/env_template
@@ -61,3 +61,6 @@ AUTH_URL="http://0.0.0.0:4000/key/info"
 
 # User agent for the crawler.
 USER_AGENT="Moodle Research Wiki-RAG Crawler/{version} (https://github.com/moodlehq/wiki-rag)"
+
+# Rate limiting setting for the crawler. Turning it off may overwhelm the server and may not be permitted by the mediawiki site.
+ENABLE_RATE_LIMITING=true

--- a/wiki_rag/load/main.py
+++ b/wiki_rag/load/main.py
@@ -98,12 +98,29 @@ def main():
         user_agent = "Moodle Research Crawler/{version} (https://git.in.moodle.com/research)"
     user_agent = f"{user_agent.format(version=__version__)}"
 
+    enable_rate_limiting_setting: str | None = os.getenv("ENABLE_RATE_LIMITING")
+    if not enable_rate_limiting_setting:
+        logger.info("ENABLE_RATE_LIMITING setting not found in environment. Using the default value 'true'")
+        enable_rate_limiting_setting = "true"
+    
+    enable_rate_limiting_setting = enable_rate_limiting_setting.lower() # lowercase it to accept different cases of true and false
+
+    if enable_rate_limiting_setting == "true":
+        enable_rate_limiting = True
+        logger.info("Rate limiting is enabled.")
+    elif enable_rate_limiting_setting == "false":
+        enable_rate_limiting = False
+        logger.info("Rate limiting is disabled.")
+    else:
+        logger.error("ENABLE_RATE_LIMITING environment variable can only get values 'true' or 'false'. Exiting.")
+        sys.exit(1)
+
     logger.info(f"Pre-loading page list for mediawiki: {mediawiki_url}, namespaces: {mediawiki_namespaces}")
     pages = get_mediawiki_pages_list(mediawiki_url, mediawiki_namespaces, user_agent)
     logger.info(f"Loaded {len(pages)} pages.")
 
-    logger.info("Parsing and splitting pages")
-    parsed_pages = get_mediawiki_parsed_pages(mediawiki_url, pages, user_agent, exclusions, keep_templates)
+    logger.info("Fetching, parsing and splitting pages")
+    parsed_pages = get_mediawiki_parsed_pages(mediawiki_url, pages, user_agent, exclusions, keep_templates, enable_rate_limiting)
     logger.info(f"Parsed {len(parsed_pages)} pages.")
 
     logger.info(f"Saving parsed pages to {dump_filename}")

--- a/wiki_rag/load/util.py
+++ b/wiki_rag/load/util.py
@@ -91,7 +91,8 @@ def get_mediawiki_parsed_pages(
         pages: list[dict],
         user_agent: str,
         exclusions: dict[str, list[str]],
-        keep_templates: list[str]
+        keep_templates: list[str],
+        enable_rate_limiting: bool,
 ) -> list[dict]:
     """Parse the pages and split them into sections.
 
@@ -100,13 +101,15 @@ def get_mediawiki_parsed_pages(
     :param user_agent: The user agent to use in the requests.
     :param exclusions: The list of exclusions to apply to the pages.
     :param keep_templates: The list of templates to keep in the wiki text.
+    :param enable_rate_limiting: A boolean that specifies whether requests should be rate limited. Default is true, can be switched off with the environment variable ENABLE_RATE_LIMITING="false"
     :return: The list of parsed pages.
     """
     parsed_pages = []
     for page in tqdm(pages, desc="Processing pages", unit="page"):
-        time.sleep(random.uniform(2, 3))  # We aren't in a hurry (it's only a few requests).
+        if enable_rate_limiting:
+            time.sleep(random.uniform(2, 3))
         try:
-            sections, categories, templates, internal_links, external_links, language_links = parse_page(
+            sections, categories, templates, internal_links, external_links, language_links = fetch_and_parse_page(
                 mediawiki_url, page["pageid"], user_agent, exclusions)  # Parse pages and sections.
             if not sections:  # Something, maybe an exclusion, caused this page to be skipped.
                 continue
@@ -136,7 +139,7 @@ def get_mediawiki_parsed_pages(
     return parsed_pages
 
 
-def parse_page(mediawiki_url: str, page_id: int, user_agent: str, exclusions: dict[str, list[str]]) -> list:
+def fetch_and_parse_page(mediawiki_url: str, page_id: int, user_agent: str, exclusions: dict[str, list[str]]) -> list:
     """Fetch a page using mediawiki api and process it completely."""
     api_url = f"{mediawiki_url}/api.php"
     headers = {


### PR DESCRIPTION
Hello,

I needed to use wiki-rag with a rather large wiki. As I knew the wiki allows bot scraping, I added an option to remove rate limits, which was essentially a wait statement with a random number of seconds. The new option is controlled by an environment variable called `ENABLE_RATE_LIMITING`. By default it is enabled (ENABLE_RATE_LIMITING=true) to discourage users from abusing servers. When rate limiting is disabled, and tested on a random wikimedia site such as `https://naruto.fandom.com/`, it will reduce the estimated fetching time from 8 hours to 1.5 hours.

Best,

Yusuf