### PR TITLE
fix(docs): bump minimum Milvus version to 2.6.14 (etcd-disconnect crash fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started with Wiki-RAG, ensure you have the following:
 - Git
 - Python 3.12 or later with pip (Python package installer)
 - [Docker](https://www.docker.com/get-started) (if you intend to run the project using Docker)
-- [Milvus 2.6.2](https://milvus.io/docs/release_notes.md) or later (for vector similarity search). Standalone or Distributed deployments are supported. Lite deployments are not supported. It's highly recommended to use the [Docker Compose deployment](https://milvus.io/docs/install_standalone-docker-compose.md) specially for testing and development purposes.
+- [Milvus 2.6.14](https://milvus.io/docs/release_notes.md) or later (for vector similarity search). Standalone or Distributed deployments are supported. Lite deployments are not supported. It's highly recommended to use the [Docker Compose deployment](https://milvus.io/docs/install_standalone-docker-compose.md) specially for testing and development purposes.
 
 ## Configuration
 
@@ -108,11 +108,11 @@ To get started with Wiki-RAG, ensure you have the following:
 
 1. Download the Milvus Docker Compose file:
    ```bash
-   wget https://github.com/milvus-io/milvus/releases/download/v2.6.2/milvus-standalone-docker-compose.yml -O milvus-standalone.yml
+   wget https://github.com/milvus-io/milvus/releases/download/v2.6.17/milvus-standalone-docker-compose.yml -O milvus-standalone.yml
    ```
    OR
    ```bash
-   curl https://github.com/milvus-io/milvus/releases/download/v2.6.2/milvus-standalone-docker-compose.yml -o milvus-standalone.yml
+   curl https://github.com/milvus-io/milvus/releases/download/v2.6.17/milvus-standalone-docker-compose.yml -o milvus-standalone.yml
    ```
 
 2. Run Wiki-RAG own Docker Compose file:


### PR DESCRIPTION
## Summary

Bumps the README's minimum supported Milvus version from **2.6.2** to **2.6.14**, and updates the inline `wget`/`curl` instructions to point at the **v2.6.17** `milvus-standalone-docker-compose.yml`. README-only change, no code touched.

## Why

Milvus standalone releases **2.6.2 through 2.6.13** are affected by a bug where a transient etcd keepalive failure causes the milvus process to exit immediately:

```
[ERROR] [proxy/proxy.go:163] ["Proxy disconnected from etcd, process will exit"]
[ERROR] [coordinator/mix_coord.go:117] ["MixCoord disconnected from etcd, process will exit"]
[ERROR] [datanode/data_node.go:162] ["Data Node disconnected from etcd, process will exit"]
```

Without a Docker `restart: unless-stopped` policy on the standalone container, this leaves the stack down until manual intervention. With a restart policy, it self-heals in ~10 s — but the underlying crash is still happening on a healthy installation.

Hit this in production following the current README on 2.6.2. The fix landed upstream in **Milvus 2.6.14** (2026-04-07, [release notes](https://milvus.io/docs/release_notes.md#v2614)). 2.6.17 is the latest 2.6.x patch at time of writing and is what new installs following the inline `wget` line should land on.

## Test plan

- [x] Confirmed a fresh `docker compose up -d` with the 2.6.17 standalone compose comes up healthy and serves queries identically to 2.6.2.
- [x] Verified `wr-load` / `wr-index` / `wr-search` / `wr-server` all work unchanged against the upgraded stack — pymilvus 2.6.9 (current pyproject pin) is server-compatible with 2.6.14+.
- [x] Confirmed existing data persists across the in-place upgrade (volume paths unchanged between 2.6.2 and 2.6.17 standalone compose files).