### PR TITLE
fix(index): skip indexing sections with empty text

### DIFF
--- a/tests/wiki_rag/index/test_util.py
+++ b/tests/wiki_rag/index/test_util.py
@@ -76,6 +76,28 @@ class TestIndexPagesSkipsDeletedPages(unittest.TestCase):
         self.assertEqual(2, mock_vector.store.insert_batch.call_count)
 
 
+class TestIndexPagesSkipsEmptySections(unittest.TestCase):
+    """index_pages() must skip sections whose text is empty after tidying."""
+
+    @patch("wiki_rag.index.util.vector")
+    @patch("wiki_rag.index.util.OpenAIEmbeddings")
+    def test_index_pages_skips_empty_and_whitespace_sections(self, mock_embeddings_cls, mock_vector):
+        """Empty and whitespace-only sections are neither embedded nor inserted."""
+        mock_embeddings = mock_embeddings_cls.return_value
+        mock_embeddings.embed_documents.return_value = [[0.1] * 4]
+
+        page = _make_page(1, num_sections=3)
+        page["sections"][0]["text"] = "Real content here."  # kept
+        page["sections"][1]["text"] = ""  # empty (e.g. a heading-only container)
+        page["sections"][2]["text"] = "   \n\t "  # whitespace-only
+
+        index_pages([page], "test_col", "model", 4)
+
+        # Only the single section with real content is embedded and inserted.
+        self.assertEqual(1, mock_embeddings.embed_documents.call_count)
+        self.assertEqual(1, mock_vector.store.insert_batch.call_count)
+
+
 class TestIndexPagesIncremental(unittest.TestCase):
     """index_pages_incremental() must route pages correctly."""
 

--- a/wiki_rag/index/util.py
+++ b/wiki_rag/index/util.py
@@ -96,6 +96,15 @@ def index_pages(
         if page.get("change_type") == "deleted":
             continue
         for section in page["sections"]:
+            # Skip sections whose body is empty after tidying — typically a
+            # heading whose content lives entirely in its subsections, or an
+            # image/template-only (or absent) page lead. Indexing them would
+            # embed the title alone, yielding a low-information vector that
+            # surfaces as a contentless hit for unrelated queries.
+            if not (section["text"] or "").strip():
+                logger.debug(f"Skipping empty section: {section['doc_title']} / {section['title']}")
+                continue
+
             # Calculate the preamble text (doc + section title).
             text_preamble = section["doc_title"]
             if section["title"] != section["doc_title"]:


### PR DESCRIPTION
## Problem

`index_pages` embeds and inserts **every** section, including ones whose `text` is empty after tidying. Two common MediaWiki structures produce empty-text sections:

- A heading whose content lives entirely in its subsections:

  ```wikitext
  == Titles ==
  === Disc 1 ===
  ...
  ```
  The `== Titles ==` section has no body of its own — the byte-offset slice between it and `=== Disc 1 ===` is just the heading markup, which `tidy_sections_text` strips to an empty string.

- A page lead that is empty or image/template-only (a page that opens straight with a heading, or whose intro is a single `[[File:…]]`), likewise stripped to nothing.

Because the dense vector is built from `preamble + "\n\n" + text` and the preamble is only the doc/section title, an empty section gets embedded **from its title alone**. That produces a low-information vector that sits at a roughly constant, middling similarity to almost any query, so these contentless chunks surface as hits with an empty `text` for unrelated queries — most visibly when a query has few strong matches.

## Fix

Skip sections whose text is empty / whitespace-only at index time, before embedding or inserting, so only sections with real content are embedded and stored.

- Covers both full and incremental indexing (`index_pages_incremental` delegates to `index_pages`).
- Genuinely short-but-real sections (e.g. a one-line definition) are unaffected — only empty/whitespace text is dropped.

## Testing

- New regression test `TestIndexPagesSkipsEmptySections`: empty and whitespace-only sections are neither embedded nor inserted (without the guard, `insert_batch` is called for them).
- `pre-commit run --all-files` passes locally (ruff, pyright, codespell, unittest — 137 tests).
