### PR TITLE
fix(index): trim section text to the varchar byte limit

### DIFF
--- a/tests/wiki_rag/index/test_util.py
+++ b/tests/wiki_rag/index/test_util.py
@@ -76,6 +76,28 @@ class TestIndexPagesSkipsDeletedPages(unittest.TestCase):
         self.assertEqual(2, mock_vector.store.insert_batch.call_count)
 
 
+class TestIndexPagesTrimsTextToByteLimit(unittest.TestCase):
+    """index_pages() must trim section text to the Milvus varchar byte limit."""
+
+    @patch("wiki_rag.index.util.vector")
+    @patch("wiki_rag.index.util.OpenAIEmbeddings")
+    def test_multibyte_text_trimmed_to_byte_limit(self, mock_embeddings_cls, mock_vector):
+        """A section under 5000 chars but over 5000 bytes is trimmed to fit the byte limit."""
+        mock_embeddings_cls.return_value.embed_documents.return_value = [[0.1] * 4]
+
+        page = _make_page(1, num_sections=1)
+        # 4000 three-byte characters = 12000 bytes: under 5000 chars but well over 5000 bytes.
+        page["sections"][0]["text"] = "€" * 4000
+        index_pages([page], "test_col", "model", 4)
+
+        record = mock_vector.store.insert_batch.call_args.args[1][0]
+        stored = record["text"]
+        # Stored text fits the byte limit and stays valid UTF-8 (no split codepoint).
+        self.assertLessEqual(len(stored.encode("utf-8")), 5000)
+        self.assertEqual(stored, stored.encode("utf-8").decode("utf-8"))
+        self.assertGreater(len(stored), 0)
+
+
 class TestIndexPagesIncremental(unittest.TestCase):
     """index_pages_incremental() must route pages correctly."""
 

--- a/wiki_rag/index/util.py
+++ b/wiki_rag/index/util.py
@@ -104,10 +104,15 @@ def index_pages(
 
             # Calculate the complete text (preamble + text, if existing).
             text_content = section["text"] if section["text"] else ""
-            if len(text_content) > 5000:
-                # TODO: We need to split the text in smaller chunks here, say 2500 max or so. For now, just trim.
-                text_content = text_content[:5000].strip()
-                logger.warning(f'Text too long for section "{text_preamble}", trimmed to 5000 characters.')
+            # The Milvus "text" varchar limit is measured in UTF-8 bytes, not
+            # characters, so trim on the encoded byte length (decoding back on a
+            # codepoint boundary) to avoid silently dropping sections that contain
+            # multi-byte characters.
+            # TODO: split oversized sections into smaller chunks here instead of trimming.
+            encoded_text = text_content.encode("utf-8")
+            if len(encoded_text) > 5000:
+                text_content = encoded_text[:5000].decode("utf-8", errors="ignore").strip()
+                logger.warning(f'Text too long for section "{text_preamble}", trimmed to 5000 bytes.')
             complete_text = text_preamble + "\n\n" + text_content
             logger.debug(f"Embedding {text_preamble}, text len {len(text_content)}")
 


### PR DESCRIPTION
## Problem

The `text` varchar field is created with `max_length=5000` (`vector/milvus.py`), and Milvus measures that limit in **UTF-8 bytes**. But `index_pages` trims with `text_content[:5000]` — **5000 characters**:

```python
if len(text_content) > 5000:
    text_content = text_content[:5000].strip()
```

So a section that is under 5000 *characters* but over 5000 *bytes* (anything with multi-byte content — em dashes, accents, non-Latin scripts) passes the length check, then fails on insert:

```
MilvusException: (code=1100, message=length of varchar field text exceeds max length,
                 length: 5050, max length: 5000: invalid parameter)
```

That exception is caught by the `try/except` around `insert_batch`, so the section is **silently dropped** (logged only as `Failed to insert data`). Observed on a real full reindex: a 5000-character trim produced a 5050-byte value that Milvus rejected.

## Fix

Trim on the encoded **byte** length, decoding back with `errors="ignore"` so the cut always lands on a UTF-8 codepoint boundary (never producing invalid UTF-8):

```python
encoded_text = text_content.encode("utf-8")
if len(encoded_text) > 5000:
    text_content = encoded_text[:5000].decode("utf-8", errors="ignore").strip()
```

This is a minimal stopgap to stop the silent data loss. It does **not** change the 5000 limit or make it configurable — that, and replacing the blunt trim with proper section splitting, is the broader work discussed in #13.

## Testing

- New regression test `TestIndexPagesTrimsTextToByteLimit`: a section of 4000 three-byte characters (12000 bytes, but under 5000 chars) is stored at ≤ 5000 bytes and remains valid UTF-8. Verified it fails on the old char-based trim (`12000 not <= 5000`) and passes with this change.
- `pre-commit run --all-files` passes (ruff, pyright, codespell, unittest — 137 tests).
