### PR TITLE
feat(index): include page categories in chunk metadata

### DIFF
--- a/tests/wiki_rag/index/test_util.py
+++ b/tests/wiki_rag/index/test_util.py
@@ -120,6 +120,25 @@ class TestIndexPagesTrimsTextToByteLimit(unittest.TestCase):
         self.assertGreater(len(stored), 0)
 
 
+class TestIndexPagesAttachesCategories(unittest.TestCase):
+    """index_pages() must copy each page's categories onto every chunk record."""
+
+    @patch("wiki_rag.index.util.vector")
+    @patch("wiki_rag.index.util.OpenAIEmbeddings")
+    def test_page_categories_attached_to_each_chunk(self, mock_embeddings_cls, mock_vector):
+        """Every section record carries its page's categories (page-level value)."""
+        mock_embeddings_cls.return_value.embed_documents.return_value = [[0.1] * 4]
+
+        page = _make_page(1, num_sections=2)
+        page["categories"] = ["Beta content", "Game Concepts"]
+        index_pages([page], "test_col", "model", 4)
+
+        self.assertEqual(2, mock_vector.store.insert_batch.call_count)
+        for call in mock_vector.store.insert_batch.call_args_list:
+            record = call.args[1][0]
+            self.assertEqual(["Beta content", "Game Concepts"], record["categories"])
+
+
 class TestIndexPagesIncremental(unittest.TestCase):
     """index_pages_incremental() must route pages correctly."""
 

--- a/wiki_rag/index/util.py
+++ b/wiki_rag/index/util.py
@@ -138,6 +138,7 @@ def index_pages(
                 "previous": [str(prv) for prv in section["previous"]],
                 "next": [str(nxt) for nxt in section["next"]],
                 "relations": [str(rel) for rel in section["relations"]],
+                "categories": [str(cat) for cat in page.get("categories", [])],
                 "page_id": int(section["page_id"]),
                 "doc_id": str(section["doc_id"]),
                 "doc_title": section["doc_title"],

--- a/wiki_rag/vector/milvus.py
+++ b/wiki_rag/vector/milvus.py
@@ -58,6 +58,7 @@ class MilvusVector(BaseVector):
         "previous",
         "next",
         "relations",
+        "categories",
         "page_id",
     )
 
@@ -409,6 +410,8 @@ class MilvusVector(BaseVector):
             FieldSchema(name="next", dtype=DataType.ARRAY, element_type=DataType.VARCHAR, max_length=4000,
                         max_capacity=100, is_array=True),
             FieldSchema(name="relations", dtype=DataType.ARRAY, element_type=DataType.VARCHAR, max_length=4000,
+                        max_capacity=100, is_array=True),
+            FieldSchema(name="categories", dtype=DataType.ARRAY, element_type=DataType.VARCHAR, max_length=4000,
                         max_capacity=100, is_array=True),
             FieldSchema(name="page_id", dtype=DataType.INT32),
             FieldSchema(name="doc_id", dtype=DataType.VARCHAR, max_length=100),


### PR DESCRIPTION
## What & why

Each page's MediaWiki **categories** are now copied onto every chunk of that page and returned on each search result. Categories come from `action=parse`, so this **includes template/module-applied categories** (e.g. a version-stamp template that adds `Beta content` or `Content outdated as of X`).

This lets a consumer act on a chunk's categories — flag beta/outdated/spoiler content, filter, route — **without re-fetching the page** or trying to infer status from the chunk text (which, after chunking, often doesn't contain the marker).

## Design

- **Dedicated field**, not embedded. `categories` is stored as `ARRAY<VARCHAR>` and returned in the retrieve output, but it is **not** part of the embedded text and **not** in the BM25 analyzer — so it never affects similarity, ranking, or sparse matching. The model just *sees* it.
- **Page-level value on every chunk.** Categories are a page property; each chunk of the page carries the same list. (The loader already fetches `page["categories"]`; this only wires it through index → schema → search.)
- **All categories**, unopinionated. wiki-rag doesn't decide which categories are "meaningful" — it surfaces them and lets the consumer decide. A configurable allow/deny filter could be layered on later if needed.

## Changes

| File | Change |
|---|---|
| `vector/milvus.py` `create_collection` | add `categories` `ARRAY<VARCHAR>` field (same style as `children`/`relations`) |
| `vector/milvus.py` `retrieve` | add `"categories"` to `output_fields` so result entities carry it |
| `index/util.py` `index_pages` | copy `page.get("categories", [])` onto each chunk record |

## Migration

Adds a collection field, so existing deployments need a **full reindex** (`wr-index --full`) after upgrading; the next incremental run picks it up automatically once the collection has the field.

## Testing

- New `TestIndexPagesAttachesCategories` asserts every chunk record carries its page's categories (verified it fails without the indexer change).
- `pre-commit run --all-files` passes (ruff, pyright, codespell, unittest — 139 tests).
